### PR TITLE
fix: Firefox 91 talk selects color

### DIFF
--- a/client/src/client/module/game/coinche/CoincheBoard.css
+++ b/client/src/client/module/game/coinche/CoincheBoard.css
@@ -359,10 +359,6 @@
   flex: 1 1 auto;
   font-size: 20px;
   font-weight: bold;
-  color: black;
-}
-.coincheBoard .talk > select {
-  background-color: rgba(100, 100, 100, .1);
 }
 .coincheBoard .talk > .sayCoincheButton {
   background-color: rgba(178,34,34, .8);


### PR DESCRIPTION
## Before (on Firefox 91)

![Capture d’écran 2021-08-18 à 20 56 09](https://user-images.githubusercontent.com/2571084/129956011-b35050d0-3b78-4710-9e39-201acb1a26c3.png)

## After (on Firefox 91)

![Capture d’écran 2021-08-18 à 20 55 53](https://user-images.githubusercontent.com/2571084/129956049-9bbd4c01-935a-47e4-979b-706a95c57068.png)
